### PR TITLE
Add toggle to save debugger response

### DIFF
--- a/OpenBullet/OB.cs
+++ b/OpenBullet/OB.cs
@@ -60,6 +60,7 @@ namespace OpenBullet
         public static readonly string envFile = @"Settings/Environment.ini";
         public static readonly string licenseFile = @"Settings/License.txt";
         public static readonly string logFile = @"Log.txt";
+        public static readonly string debuggerResponseFile = @"DebuggerResponse.txt";
         public static readonly string configFolder = @"Configs";
         public static readonly string pluginsFolder = @"Plugins";
         public static readonly string defaultProxySiteUrl = "https://google.com";

--- a/OpenBullet/ViewModels/StackerViewModel.cs
+++ b/OpenBullet/ViewModels/StackerViewModel.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Windows;
 using System.Windows.Media;
 
 namespace OpenBullet.ViewModels
@@ -153,6 +154,14 @@ namespace OpenBullet.ViewModels
 
         private bool sbsEnabled = false;
         public bool SBSEnabled { get { return sbsEnabled; } set { sbsEnabled = value; OnPropertyChanged(); } }
+
+        private bool saveResponseToFile = false;
+        public bool SaveResponseToFile { get { return saveResponseToFile; } set { saveResponseToFile = value; OnPropertyChanged(); OnPropertyChanged(nameof(ResponseFileButtonVisibility)); } }
+
+        public string ResponseFilePath { get; set; } = OB.debuggerResponseFile;
+
+        public System.Windows.Visibility ResponseFileButtonVisibility
+            => SaveResponseToFile ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
 
         // Search
         private string searchString = "";

--- a/OpenBullet/Views/Main/Configs/Stacker.xaml
+++ b/OpenBullet/Views/Main/Configs/Stacker.xaml
@@ -192,6 +192,8 @@
                 <Button DockPanel.Dock="Left" x:Name="startDebuggerButton" Content="Start" Click="startDebuggerButton_Click" ToolTip="Start the Debugger"/>
                 <CheckBox DockPanel.Dock="Left" IsEnabled="{Binding ControlsEnabled}" Content="SBS" IsChecked="{Binding SBS}" VerticalContentAlignment="Center" ToolTip="Step By Step"/>
                 <Button DockPanel.Dock="Left" IsEnabled="{Binding SBSEnabled}" x:Name="nextStepButton" Content="Step" Click="nextStepButton_Click" Margin="5 0 0 0" ToolTip="Take another Step"/>
+                <CheckBox DockPanel.Dock="Left" Content="Save Resp." IsChecked="{Binding SaveResponseToFile}" VerticalContentAlignment="Center" Margin="5 0"/>
+                <Button DockPanel.Dock="Left" Content="Open File" Margin="5 0" Visibility="{Binding ResponseFileButtonVisibility}" Click="openResponseFileButton_Click"/>
                 <Label DockPanel.Dock="Left" Content="Data:" VerticalAlignment="Center"/>
                 <Grid>
                     <Grid.ColumnDefinitions>

--- a/OpenBullet/Views/Main/Configs/Stacker.xaml.cs
+++ b/OpenBullet/Views/Main/Configs/Stacker.xaml.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
@@ -450,7 +451,16 @@ namespace OpenBullet.Views.Main.Configs
             if (vm.BotData.LogBuffer.Count == 0) return;
             App.Current.Dispatcher.Invoke(new Action(() => {
                 foreach (LogEntry entry in vm.BotData.LogBuffer)
+                {
+                    if (vm.SaveResponseToFile &&
+                        (entry.LogString == "Response Source:" || entry.LogString == vm.BotData.ResponseSource))
+                        continue;
+
                     logRTB.AppendText(entry.LogString, entry.LogColor);
+                }
+
+                if (vm.SaveResponseToFile)
+                    logRTB.AppendText($"[Response saved to {vm.ResponseFilePath}]", Colors.Gray);
 
                 vm.BotData.LogBuffer.Add(new LogEntry(Environment.NewLine, Colors.White));
 
@@ -494,6 +504,12 @@ namespace OpenBullet.Views.Main.Configs
                 if (vm.BotData.ResponseSource != string.Empty)
                 {
                     htmlViewBrowser.DocumentText = vm.BotData.ResponseSource.Replace("alert(", "(");
+
+                    if (vm.SaveResponseToFile)
+                    {
+                        try { File.WriteAllText(vm.ResponseFilePath, vm.BotData.ResponseSource); }
+                        catch { }
+                    }
                 }
             }));
         }
@@ -810,6 +826,12 @@ namespace OpenBullet.Views.Main.Configs
         private void openDocButton_Click(object sender, RoutedEventArgs e)
         {
             (new MainDialog(new DialogLSDoc(), "LoliScript Documentation")).Show();
+        }
+
+        private void openResponseFileButton_Click(object sender, RoutedEventArgs e)
+        {
+            try { System.Diagnostics.Process.Start(vm.ResponseFilePath); }
+            catch { }
         }
     }
 


### PR DESCRIPTION
## Summary
- introduce `debuggerResponseFile` constant
- allow Stacker debugger to save response text to file
- show/hide file button depending on toggle state
- filter response contents from log when saving to file
- fix `Process.Start` compile error

## Testing
- `dotnet build OpenBullet.sln` *(fails: command not found)*
- `msbuild OpenBullet.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843705e30448324ad1de308dc86419f